### PR TITLE
Fix NER filter usage

### DIFF
--- a/search_engine/vector_search.py
+++ b/search_engine/vector_search.py
@@ -159,6 +159,10 @@ def vector_search_ner(
             ]
             doc_text = " ".join(doc_text_parts)
 
+            # Фильтруем кандидатов на основе найденных сущностей NER
+            if filters and not passes_ner_filters(src, filters):
+                continue
+
             d_vec = model.encode(doc_text)
             sim = float((q_vec @ d_vec) / (np.linalg.norm(q_vec) * np.linalg.norm(d_vec) + 1e-8))
 


### PR DESCRIPTION
## Summary
- apply detected NER filters when ranking contacts

## Testing
- `pytest -q` *(fails: FileNotFoundError for classifier model)*

------
https://chatgpt.com/codex/tasks/task_e_684b24e7754883329334de8a1a1cd8e1